### PR TITLE
fix: Create Gradle home dir

### DIFF
--- a/runDevEnvironment.sh
+++ b/runDevEnvironment.sh
@@ -30,6 +30,7 @@ main() {
     fi
 
     if [ -z "$NO_RUN" ]; then
+        mkdir --parents "$GRADLE_HOME_DIR"
         # shellcheck disable=SC2086
         docker run --rm $DOCKER_OPTIONS \
             --volume "$PWD:/app" \


### PR DESCRIPTION
Manually create Gradle home dir before starting Docker container to avoid creation of new directory owned by root